### PR TITLE
Itemsapi package

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,27 +1,39 @@
 'use strict';
 
-var server = null;
+var itemsapi = require('./server');
+var logger = require('./config/logger')
 
-var winston = require('winston');
-
-winston.loggers.add('query', {
-  console: {
-    level: 'info',
-    colorize: true,
-    prettyPrint: true,
-    label: 'query'
+itemsapi.init({
+  elasticsearch: {
+    host: "localhost:9200",
+    log: "error"
   },
-  file: {
-    json: true,
-    filename: './data/logs/query.log'
+  server: {
+    host: "http://127.0.0.1",
+    port: 3000
+  },
+  collections: {
+    db: "json",
+    filename:  "./config/collections.json"
   }
-});
+})
 
-server = require('./server');
-server.start(function serverStart(serverInstance) {
+
+// should be implemented in custom application not in itemsapi itself
+/*if (config.hooks && config.hooks.limiter && config.hooks.limiter.enabled === true) {
+  var client = require('redis').createClient(config.redis);
+  // limit requests per IP
+  var limiter = require('./hooks/limiter')(router, client);
+}*/
+
+var winston = require('winston')
+
+itemsapi.get('logger').info('it works!')
+
+itemsapi.start(function serverStart(serverInstance) {
   var host = serverInstance.address().address;
   var port = serverInstance.address().port;
 
-  console.log('server started');
-  console.log('Example app listening at http://%s:%s', host, port);
+  logger.info('server started');
+  logger.info('app listening at http://%s:%s', host, port);
 });

--- a/app.js
+++ b/app.js
@@ -4,20 +4,10 @@ var itemsapi = require('./server');
 var logger = require('./config/logger')
 
 itemsapi.init({
-  elasticsearch: {
-    host: "localhost:9200",
-    log: "error"
-  },
-  server: {
-    host: "http://127.0.0.1",
-    port: 3000
-  },
-  collections: {
-    db: "json",
-    filename:  "./config/collections.json"
-  }
+  //server: {
+    //port: 3002
+  //},
 })
-
 
 // should be implemented in custom application not in itemsapi itself
 /*if (config.hooks && config.hooks.limiter && config.hooks.limiter.enabled === true) {

--- a/cli.js
+++ b/cli.js
@@ -1,17 +1,9 @@
 'use strict';
 
-var nconf = require('nconf');
 var fs = require('fs');
-var configFile = './config/local.json';
 
-nconf.use('memory');
-if (fs.existsSync(configFile) !== false) {
-  nconf.file('overrides', {file: configFile})
-}
-
-nconf.file('defaults', {file: './config/root.json'});
-
-var server = require('./server');
+// should be deleted or refactored
+var itemsapi = require('./server');
 var importService = require('./src/services/import');
 var collectionService = require('./src/services/collection');
 var documentService = require('./src/services/data');

--- a/config/index.js
+++ b/config/index.js
@@ -32,7 +32,7 @@ if (process.env.SEARCHBOX_URL) {
 exports.get = function() {
   return nconf.get();
 }
-exports.overrides = function(data) {
+exports.merge = function(data) {
   nconf.merge(data)
 }
 exports.set = function(key, value) {

--- a/config/index.js
+++ b/config/index.js
@@ -29,4 +29,14 @@ if (process.env.SEARCHBOX_URL) {
   nconf.set('elasticsearch:host', process.env.ELASTICSEARCH_URL);
 }
 
-module.exports = nconf.get();
+exports.get = function() {
+  return nconf.get();
+}
+exports.overrides = function(data) {
+  nconf.merge(data)
+}
+exports.set = function(key, value) {
+  nconf.set(key, value);
+}
+module.exports = exports;
+

--- a/config/logger.js
+++ b/config/logger.js
@@ -1,0 +1,10 @@
+var winston = require('winston')
+var util = require('util');
+
+var logger = new (winston.Logger)({
+  transports: [
+    new (winston.transports.Console)(),
+  ]
+});
+
+module.exports = logger;

--- a/express.js
+++ b/express.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var express = require('express');
+var app = express();
+var bodyParser = require('body-parser');
+var gzip = require('compression');
+var router = express.Router();
+var cors = require('cors');
+var httpNotFound = 404;
+var httpBadRequest = 400;
+var apiPrefix = '/api/v1';
+var logger = require('./config/logger')
+
+var morgan = require('morgan')
+
+app.locals.environment = process.env.NODE_ENV || 'development';
+app.disable('etag');
+app.disable('x-powered-by');
+app.use(gzip({treshold: 512}));
+app.use(bodyParser.json({
+  limit: '4mb'
+}));
+
+app.use(cors());
+app.use(apiPrefix, router);
+
+var winstonStream = {
+  write: function(message, encoding){
+    logger.info(message);
+  }
+};
+
+// that needs to be place out of itemsapi
+router.use(morgan(':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" - :response-time ms', {stream: winstonStream}))
+router.use(function(req, res, next){
+  logger.info(req.method, req.url, "query", req.query, "body", JSON.stringify(req.body));
+  next();
+});
+
+// all collections, stats
+var itemsRoutes = require('./routes/additional')(router);
+
+// manage collections (schema, aggregations options, sortings, etc)
+var collectionsRoutes = require('./routes/collections')(router);
+
+// get, put, post, delete, find, similar, autocomplete etc
+var itemsRoutes = require('./routes/items')(router);
+
+app.use(function errorRoute(err, req, res, next) {
+  // need to test it out
+  logger.error(err, err.stack)
+  res.status(httpBadRequest).json(err);
+  next();
+});
+
+// should export object
+// app and api router and maybe another things in the future
+module.exports = app;

--- a/nodemon.json
+++ b/nodemon.json
@@ -13,9 +13,11 @@
   },
   "watch": [
     "src/",
+    "config/",
     "hooks/",
     "routes/",
     "server.js",
+    "express.js",
     "app.js"
   ],
   "env": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "morgan": "^1.7.0",
     "nconf": "^0.7.1",
     "redis": "^2.2.5",
-    "request": "^2.53.0",
     "underscore": "^1.8.3",
     "validate.js": "^0.4.0",
     "winston": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "async": "^0.9.2",
-    "bluebird": "^2.10.0",
+    "bluebird": "^3.3.3",
     "body-parser": "^1.13.1",
     "cli": "^0.8.0",
     "compression": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "itemsapi",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "creating search application without spending time for backend",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "NODE_ENV=test mocha tests/*",
     "start": "node app.js"
@@ -36,12 +36,13 @@
     "express-limiter": "^1.6.0",
     "fs-extra": "^0.26.2",
     "lodash": "^3.9.3",
+    "morgan": "^1.7.0",
     "nconf": "^0.7.1",
     "redis": "^2.2.5",
     "request": "^2.53.0",
     "underscore": "^1.8.3",
     "validate.js": "^0.4.0",
-    "winston": "^0.8.3"
+    "winston": "^2.2.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/server.js
+++ b/server.js
@@ -1,30 +1,32 @@
 'use strict';
 
-var config = require('./config/index').get();
+var config = require('./config/index');
 var logger = require('./config/logger');
 var server;
+var app;
 
 exports.init = function (data) {
+  logger.info('app initialized');
+  data = data || {};
+  config.merge(data);
+  require('./src/connections/elastic').init(config.get().elasticsearch);
+  app = require('./express');
 };
+
 
 exports.get = function (name) {
   if (name === 'config') {
-    return config;
+    return config.get();
   } else if (name === 'logger') {
     return logger;
   }
 };
 
-var elastic = require('./src/connections/elastic');
-elastic.init(config.elasticsearch);
-
-var app = require('./express')
-
 /**
  * start server
  */
 exports.start = function start(done) {
-  server = app.listen(config.server.port, function afterListen() {
+  server = app.listen(config.get().server.port, function afterListen() {
     done(server);
   });
 };
@@ -36,7 +38,6 @@ exports.stop = function stop(done) {
   server.close(function() {
     done();
   })
-  //server.close();
 };
 
 module.exports = exports;

--- a/server.js
+++ b/server.js
@@ -1,54 +1,24 @@
 'use strict';
 
-var express = require('express');
-var app = express();
-var bodyParser = require('body-parser');
-var gzip = require('compression');
-var config = require('./config/index');
-var _ = require('underscore');
-var router = express.Router();
-var cors = require('cors');
+var config = require('./config/index').get();
+var logger = require('./config/logger');
 var server;
-var httpNotFound = 404;
-var httpBadRequest = 400;
-var Promise = require('bluebird');
 
-app.locals.environment = process.env.NODE_ENV || 'development';
-app.disable('etag');
-app.disable('x-powered-by');
-app.use(gzip({treshold: 512}));
-app.use(bodyParser.json({
-  limit: '4mb'
-}));
+exports.init = function (data) {
+};
 
-app.use(cors());
-app.use('/api/v1', router);
+exports.get = function (name) {
+  if (name === 'config') {
+    return config;
+  } else if (name === 'logger') {
+    return logger;
+  }
+};
 
 var elastic = require('./src/connections/elastic');
 elastic.init(config.elasticsearch);
 
-
-if (config.hooks && config.hooks.limiter && config.hooks.limiter.enabled === true) {
-  var client = require('redis').createClient(config.redis);
-  // limit requests per IP
-  var limiter = require('./hooks/limiter')(router, client);
-}
-
-// all collections, stats
-var itemsRoutes = require('./routes/additional')(router);
-
-// manage collections (schema, aggregations options, sortings, etc)
-var collectionsRoutes = require('./routes/collections')(router);
-
-// get, put, post, delete, find, similar, autocomplete etc
-var itemsRoutes = require('./routes/items')(router);
-
-app.use(function errorRoute(err, req, res, next) {
-  console.log(err);
-  console.log(err.stack);
-  res.status(httpBadRequest).json(err);
-  next();
-});
+var app = require('./express')
 
 /**
  * start server
@@ -62,8 +32,11 @@ exports.start = function start(done) {
 /**
  * stop server
  */
-exports.stop = function start() {
-  server.close();
+exports.stop = function stop(done) {
+  server.close(function() {
+    done();
+  })
+  //server.close();
 };
 
-exports.app = app;
+module.exports = exports;

--- a/src/connections/elastic.js
+++ b/src/connections/elastic.js
@@ -3,8 +3,7 @@
 (function(module) {
 
   var elasticsearch = require('elasticsearch');
-  var winston = require('winston');
-  var nconf = require('nconf');
+  var logger = require('../../config/logger');
   var client;
 
   module.init = function(conf) {
@@ -14,8 +13,8 @@
         log: conf.log
       });
     } catch (err) {
-      winston.error('Unable to initialize elasticsearch! Error :' + err.message);
-      return callback(err);
+      logger.error('Unable to initialize elasticsearch! Error :' + err.message);
+      //return callback(err);
     }
 
     module.elastic = client;

--- a/src/elastic/data.js
+++ b/src/elastic/data.js
@@ -129,7 +129,7 @@ var validate = require('validate.js');
       index: data.index,
       type: data.type,
     }).then(function(res) {
-      return res[0].count;
+      return res.count;
     });
   }
 

--- a/src/elastic/mapping.js
+++ b/src/elastic/mapping.js
@@ -3,7 +3,7 @@
 var winston = require('winston');
 var Promise = require('bluebird');
 var elastic = Promise.promisifyAll(require('../connections/elastic').getElastic());
-var indices = Promise.promisifyAll(require('../connections/elastic').getElastic().indices);
+var indices = elastic.indices;
 var _ = require('lodash');
 var validate = require('validate.js');
 
@@ -130,7 +130,7 @@ var validate = require('validate.js');
   /**
    * delete mapping
    */
-  module.deleteMappingAsync = function(data, callback) {
+  module.deleteMappingAsync = function(data) {
     return module.existsMappingAsync(data)
     .then(function (res) {
       if (!res) {
@@ -142,7 +142,7 @@ var validate = require('validate.js');
 
       return indices.deleteMappingAsync(data)
       .then(function (res) {
-        return res[0];
+        return res;
       })
     })
   },
@@ -170,7 +170,7 @@ var validate = require('validate.js');
   module.getMappingAsync = function(data) {
     return elastic.indices.getMappingAsync(data)
     .then(function (res) {
-      return res[0];
+      return res;
     })
   }
 

--- a/src/elastic/mapping.js
+++ b/src/elastic/mapping.js
@@ -3,7 +3,7 @@
 var winston = require('winston');
 var Promise = require('bluebird');
 var elastic = Promise.promisifyAll(require('../connections/elastic').getElastic());
-var indices = elastic.indices;
+var indices = Promise.promisifyAll(require('../connections/elastic').getElastic().indices);
 var _ = require('lodash');
 var validate = require('validate.js');
 

--- a/src/elastic/stats.js
+++ b/src/elastic/stats.js
@@ -17,7 +17,7 @@ var _ = require('lodash');
       bytes: data.bytes || 'm'
     })
     .then(function(res) {
-      return res[0];
+      return res;
     });
   }
 }(exports));

--- a/src/elastic/tools.js
+++ b/src/elastic/tools.js
@@ -17,7 +17,7 @@ var _ = require('lodash');
       force: true
     })
     .then(function(res) {
-      return res[0];
+      return res;
     });
   }
 }(exports));

--- a/src/services/collection.js
+++ b/src/services/collection.js
@@ -1,7 +1,7 @@
 'use strict';
 var Promise = require('bluebird');
 var _ = require('lodash');
-var config = require('./../../config/index');
+var config = require('./../../config/index').get();
 var fs = Promise.promisifyAll(require('fs-extra'));
 
 (function(module) {

--- a/tests/config/confSpec.js
+++ b/tests/config/confSpec.js
@@ -16,7 +16,29 @@ setup.makeSuite('conf tool', function() {
   });
 
   it('should return project name in testing env', function test(done) {
-    config.project.name.should.be.equal('test');
+    config.get().project.name.should.be.equal('test');
+    config.get().elasticsearch.should.be.an.Object;
+    config.get().elasticsearch.should.be.an.Object;
+    config.get().server.should.be.an.Object;
+    config.set('test', 'test');
+    config.get().test.should.be.equal('test');
+    config.overrides({
+      test: 'test2',
+      a: {
+        b: 'b',
+        c: 'c'
+      }
+    });
+    config.get().test.should.be.equal('test2');
+    config.get().a.b.should.be.equal('b');
+    config.get().a.c.should.be.equal('c');
+    config.overrides({
+      a: {
+        b: 'b2'
+      }
+    });
+    config.get().a.b.should.be.equal('b2');
+    config.get().a.c.should.be.equal('c');
     done();
   });
 });

--- a/tests/config/confSpec.js
+++ b/tests/config/confSpec.js
@@ -22,7 +22,7 @@ setup.makeSuite('conf tool', function() {
     config.get().server.should.be.an.Object;
     config.set('test', 'test');
     config.get().test.should.be.equal('test');
-    config.overrides({
+    config.merge({
       test: 'test2',
       a: {
         b: 'b',
@@ -32,7 +32,7 @@ setup.makeSuite('conf tool', function() {
     config.get().test.should.be.equal('test2');
     config.get().a.b.should.be.equal('b');
     config.get().a.c.should.be.equal('c');
-    config.overrides({
+    config.merge({
       a: {
         b: 'b2'
       }

--- a/tests/item/crudSpec.js
+++ b/tests/item/crudSpec.js
@@ -11,6 +11,7 @@ setup.makeSuite('item crud request', function() {
   var projectService = require('./../../src/services/project');
   var collectionService = require('./../../src/services/collection');
   var documentElastic = require('./../../src/elastic/data');
+  var searchElastic = require('./../../src/elastic/search');
   var elasticTools = require('./../../src/elastic/tools');
   var elastic = require('./../../src/connections/elastic').getElastic();
 
@@ -75,16 +76,19 @@ setup.makeSuite('item crud request', function() {
   });
 
   it('should make successfull get (find) request', function(done) {
-    var spy = sinon.spy(elastic, 'search');
+    //var spy = sinon.spy(elastic, 'search');
+    var spy = sinon.spy(searchElastic, 'search');
     request(setup.getServer())
       .get('/api/v1/movie')
       .end(function afterRequest(err, res) {
         res.should.have.property('status', 200);
         res.body.pagination.should.have.property('total', 1);
         assert(spy.calledOnce);
-        assert(spy.calledWithMatch({type: 'movie'}));
-        assert(spy.calledWithMatch({index: 'test'}));
-        elastic.search.restore();
+        //console.log(spy.args[0]);
+        //assert(spy.calledWithMatch({type: 'movie'}));
+        assert(spy.calledWithMatch({collectionName: 'movie'}));
+        //assert(spy.calledWithMatch({index: 'test'}));
+        spy.restore();
         done();
       });
   });

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -22,7 +22,7 @@ var server;
   module.makeSuite = function addSuite(name, tests) {
 
     process.env.NODE_ENV = 'test';
-    var config = require('./../../config/index');
+    var config = require('./../../config/index').get();
 
     server  = require(__dirname + '/../../server.js');
 
@@ -40,8 +40,9 @@ var server;
       tests();
 
       after(function after(done) {
-        server.stop();
-        done();
+        server.stop(function(res) {
+          done();
+        });
       });
     });
   };

--- a/tests/mocks/setup.js
+++ b/tests/mocks/setup.js
@@ -19,12 +19,14 @@ var server;
     serverInstance = server;
   };
 
+
   module.makeSuite = function addSuite(name, tests) {
 
     process.env.NODE_ENV = 'test';
     var config = require('./../../config/index').get();
 
     server  = require(__dirname + '/../../server.js');
+    server.init();
 
     describe(name, function describe() {
       before(function before(done) {


### PR DESCRIPTION
Current PR allows ItemsAPI to work as a standalone external package.
You could run ItemsAPI in external node.js project or integrate with another express.js application i.e. keystone.js.

Example:
```js
var itemsapi = require('itemsapi');
var winston = require('winston')

// removing the native logger transport
itemsapi.get('logger').remove(winston.transports.Console);
itemsapi.get('logger').add(winston.transports.Console, {
  timestamp: true,
  colorize: true
})

itemsapi.init({
  server: {
    port: 3051
  },
  collections: {
    db: 'json',
    filename:  './collections.json'
  },
})

itemsapi.start(function serverStart(serverInstance) {
  var host = serverInstance.address().address;
  var port = serverInstance.address().port;
  itemsapi.get('logger').info('ItemsAPI started on http://%s:%s', host, port)
});
```

