### PR TITLE
aggregation internal pagionation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itemsapi",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "creating search application without spending time for backend",
   "main": "server.js",
   "scripts": {

--- a/src/controllers/items.js
+++ b/src/controllers/items.js
@@ -210,10 +210,12 @@ exports.facets = function facets(req, res, next) {
 };
 
 exports.facet = function searchItems(req, res, next) {
-  return searchService.getFacetAsync({
+  return searchService.getProcessedFacetAsync({
     collectionName: req.params.name,
     facetName: req.params.facet,
-    size: req.query.size
+    size: parseInt(req.query.size || 100),
+    per_page: parseInt(req.query.per_page || 10),
+    page: parseInt(req.query.page || 1)
   })
   .then(function(result) {
     return res.json(result);

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -83,6 +83,36 @@ exports.getFacetAsync = function(data) {
   })
 }
 
+exports.getProcessedFacetAsync = function(data) {
+  return exports.getFacetAsync(data)
+  .then(function(facet) {
+    var offset = data.per_page * (data.page - 1)
+    facet.data = {
+      buckets: facet.buckets.slice(
+        offset,
+        offset + data.per_page
+      )
+    }
+    facet.pagination = {
+      page: data.page,
+      per_page: data.per_page,
+      total: facet.doc_count
+    }
+
+    facet.meta = {
+      title: facet.title,
+      name: facet.name,
+      type: facet.type
+    }
+
+    facet = _.omit(facet, ['doc_count', 'size', 'title', 'name', 'type', 'buckets'])
+    return facet
+  })
+
+}
+
+
+
 /**
  * search documents
  */


### PR DESCRIPTION
Here is how pagination for `http://localhost:3050/api/v1/facets/cars/class/?per_page=2&page=3&size=100000` looks like:

![selection_454](https://cloud.githubusercontent.com/assets/1032493/16772566/05a27454-4855-11e6-9fd9-bad11576eff3.jpg)

`per_page` - buckets amount per page
`page` - current page
`size` - how much elements is loaded from elasticsearch (default 100)

The response structure is quite similar to search response

The cache feature will be in the next PR. Who knows maybe we could add sorting (count desc, key asc), option in the future too.