### PR TITLE
Querystring language

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itemsapi",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "creating search application without spending time for backend",
   "main": "server.js",
   "scripts": {

--- a/src/controllers/items.js
+++ b/src/controllers/items.js
@@ -162,7 +162,7 @@ var searchItemsAsync = function(req, res, next) {
     page: page,
     per_page: per_page,
     query: req.query.query || '',
-    querystring: req.query.querystring || '',
+    query_string: req.query.query_string || '',
     sort: req.query.sort || '',
     key: req.query.key || '',
     val: req.query.val || '',

--- a/src/controllers/items.js
+++ b/src/controllers/items.js
@@ -162,6 +162,7 @@ var searchItemsAsync = function(req, res, next) {
     page: page,
     per_page: per_page,
     query: req.query.query || '',
+    querystring: req.query.querystring || '',
     sort: req.query.sort || '',
     key: req.query.key || '',
     val: req.query.val || '',

--- a/src/elastic/search.js
+++ b/src/elastic/search.js
@@ -55,7 +55,11 @@ exports.searchAsync = function(data, collection) {
 
   if (data.key && data.val) {
     body.query(ejs.TermQuery(data.key, data.val));
+  } else if (data.querystring) {
+    // i.e. 'actor:Pacino AND genre:Dram*'
+    body.query(ejs.QueryStringQuery(data.querystring));
   } else if (data.query) {
+    // i.e. 'Al Pacino'
     body.query(ejs.QueryStringQuery('"' + data.query + '"'));
   }
 

--- a/src/elastic/search.js
+++ b/src/elastic/search.js
@@ -55,9 +55,9 @@ exports.searchAsync = function(data, collection) {
 
   if (data.key && data.val) {
     body.query(ejs.TermQuery(data.key, data.val));
-  } else if (data.querystring) {
+  } else if (data.query_string) {
     // i.e. 'actor:Pacino AND genre:Dram*'
-    body.query(ejs.QueryStringQuery(data.querystring));
+    body.query(ejs.QueryStringQuery(data.query_string));
   } else if (data.query) {
     // i.e. 'Al Pacino'
     body.query(ejs.QueryStringQuery('"' + data.query + '"'));

--- a/tests/services/searchSpec.js
+++ b/tests/services/searchSpec.js
@@ -90,7 +90,7 @@ setup.makeSuite('search service', function() {
   it('should search using the querystring language', function(done) {
     searchService.searchAsync({
       collectionName: 'movie',
-      querystring: 'name:FIG*'
+      query_string: 'name:FIG*'
     }).then(function(res) {
       res.data.should.have.property('items').and.lengthOf(1);
       done();
@@ -100,7 +100,7 @@ setup.makeSuite('search service', function() {
   it('should search using the querystring language 2', function(done) {
     searchService.searchAsync({
       collectionName: 'movie',
-      querystring: 'name:FIG* OR name:Godfather'
+      query_string: 'name:FIG* OR name:Godfather'
     }).then(function(res) {
       res.data.should.have.property('items').and.lengthOf(2);
       done();

--- a/tests/services/searchSpec.js
+++ b/tests/services/searchSpec.js
@@ -86,6 +86,27 @@ setup.makeSuite('search service', function() {
     });
   });
 
+  // https://www.elastic.co/guide/en/elasticsearch/reference/1.7/query-dsl-query-string-query.html
+  it('should search using the querystring language', function(done) {
+    searchService.searchAsync({
+      collectionName: 'movie',
+      querystring: 'name:FIG*'
+    }).then(function(res) {
+      res.data.should.have.property('items').and.lengthOf(1);
+      done();
+    });
+  });
+
+  it('should search using the querystring language 2', function(done) {
+    searchService.searchAsync({
+      collectionName: 'movie',
+      querystring: 'name:FIG* OR name:Godfather'
+    }).then(function(res) {
+      res.data.should.have.property('items').and.lengthOf(2);
+      done();
+    });
+  });
+
   it('should search city and get aggregations as array', function(done) {
     searchService.searchAsync({
       collectionName: 'city'


### PR DESCRIPTION
accept lucene query_string
https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-query-string-query.html#query-dsl-query-string-query (currently without additional options)

for more sophisticated search this is possible to use native elasticsearch search i.e. `POST` `/api/v1/items/cars/_search` i.e. `curl -XPOST https://itemsapi.herokuapp.com/api/v1/items/wikipedia-cars/_search | jq '.'`