### PR TITLE
aggregation directly by field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itemsapi",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "creating search application without spending time for backend",
   "main": "server.js",
   "scripts": {

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -132,11 +132,13 @@ module.exports = function(router) {
 
   /**
    * get list of facets with values
+   * not specified in documentation. not recommended to use
    */
   router.get(['/facets/:name'], items.facets);
 
   /**
    * get facet with values (configured by size)
+   * not specified in documentation. not recommended to use
    */
   router.get(['/facets/:name/:facet'], items.facet);
 
@@ -144,6 +146,11 @@ module.exports = function(router) {
    * get facet with values (configured by size)
    */
   router.get(['/aggregations/:name/:facet'], items.facet);
+
+  /**
+   * get facet with values (configured by size)
+   */
+  router.get(['/aggregations/:name/field/:field_name'], items.facet);
 
   /*
    * search items using native (prefiltered) elasticsearch /_search endpoint

--- a/src/controllers/items.js
+++ b/src/controllers/items.js
@@ -216,6 +216,7 @@ exports.facet = function searchItems(req, res, next) {
   return searchService.getProcessedFacetAsync({
     collectionName: req.params.name,
     facetName: req.params.facet,
+    fieldName: req.params.field_name,
     size: req.query.size,
     per_page: req.query.per_page,
     page: req.query.page,

--- a/src/helpers/collection.js
+++ b/src/helpers/collection.js
@@ -57,6 +57,18 @@ module.exports = function(data) {
     }
   }
 
+  /**
+   * add aggregation on fly (by field)
+   * by field, value or object with key value pairs
+   */
+  var addAggregation = function(name, obj) {
+    if (_.isArray(data.aggregations)) {
+      obj.name = name
+      data.aggregations.push(obj)
+    } else {
+      data.aggregations[name] = obj
+    }
+  }
 
   /**
    * be careful with using that
@@ -169,6 +181,7 @@ module.exports = function(data) {
     getSlugs: getSlugs,
     getMetadata: getMetadata,
     getCollection: getCollection,
-    updateAggregation: updateAggregation
+    updateAggregation: updateAggregation,
+    addAggregation: addAggregation
   }
 };

--- a/src/helpers/collection.js
+++ b/src/helpers/collection.js
@@ -64,7 +64,15 @@ module.exports = function(data) {
   var addAggregation = function(name, obj) {
     if (_.isArray(data.aggregations)) {
       obj.name = name
-      data.aggregations.push(obj)
+
+      var index = _.findIndex(data.aggregations, {
+        name: name
+      })
+      if (!data.aggregations[index]) {
+        data.aggregations.push(obj)
+      } else {
+        data.aggregations[index] = obj
+      }
     } else {
       data.aggregations[name] = obj
     }

--- a/tests/services/aggregationsSpec.js
+++ b/tests/services/aggregationsSpec.js
@@ -199,4 +199,36 @@ setup.makeSuite('search service', function() {
       done();
     })
   })
+
+  it('should get processed aggregation by field name (from schema)', function(done) {
+    searchService.getProcessedFacetAsync({
+      collectionName: 'movie',
+      fieldName: 'actors',
+      per_page: 4
+    }).then(function(res) {
+      res.should.have.properties(['data', 'pagination', 'meta'])
+      res.pagination.should.have.properties({
+        page: 1,
+        per_page: 4,
+        total: 4
+      })
+
+      _.map(res.data.buckets, 'key').should.eql(
+        ['a', 'b', 'c']
+      )
+      done();
+    })
+  })
+
+  it('should not get processed aggregation because of unexistent field', function(done) {
+    searchService.getProcessedFacetAsync({
+      collectionName: 'movie',
+      fieldName: 'actors_not_exist',
+      per_page: 4
+    }).catch(function(error) {
+      console.log(error.message);
+      done();
+    })
+  })
+
 })


### PR DESCRIPTION
It is very similar to this:  
- /api/v1/aggregations/:collection/:aggregation_name

but allows to also aggregate by field directly (without defining aggregation in configuration):

- /api/v1/aggregations/:collection/field/:field_name

Very helpful for autocomplete for specific field (like below)
![selection_547](https://cloud.githubusercontent.com/assets/1032493/18760727/90786fd0-8102-11e6-9010-ef0f1f7c0707.jpg)

More details:
https://itemsapi.readme.io/docs/aggregationscollectionaggregation_name