### PR TITLE
Multi field sorting

### DIFF
--- a/config/collections_test.json
+++ b/config/collections_test.json
@@ -74,6 +74,34 @@
                 "type": "normal",
                 "order": "desc",
                 "field": "played"
+            },
+            "rating": {
+                "title": "Rating",
+                "type": "normal",
+                "order": "desc",
+                "field": "rating"
+            },
+            "mix": {
+                "title": "Rating",
+                "type": "normal",
+                "sort": [
+                    {
+                        "name": {
+                            "order": "asc"
+                        }
+                    },
+                    {
+                        "rating": {
+                            "order": "desc"
+                        }
+                    }
+                ]
+            },
+            "alphabetically": {
+                "title": "AZ",
+                "type": "normal",
+                "order": "asc",
+                "field": "name"
             }
         },
         "table": {

--- a/src/controllers/items.js
+++ b/src/controllers/items.js
@@ -183,6 +183,8 @@ var searchItemsAsync = function(req, res, next) {
   .then(function(result) {
     result.meta.search_time = Date.now() - time;
     return result;
+  }).catch(function(error) {
+    return next(error);
   })
 };
 

--- a/src/services/project.js
+++ b/src/services/project.js
@@ -206,7 +206,7 @@ exports.updateMappingAsync = function(data) {
       index: helper.getIndex(),
       type: helper.getType(),
       body: {
-        properties: collection.schema
+        properties: helper.getElasticSchema()
       }
     })
   })

--- a/tests/fixtures/movie_collection.json
+++ b/tests/fixtures/movie_collection.json
@@ -1,0 +1,110 @@
+{
+    "name": "movie",
+    "project": "test",
+    "schema": {
+        "name": {
+            "type": "string",
+            "store": true
+        },
+        "permalink": {
+            "type": "string",
+            "store": true,
+            "index": "not_analyzed"
+        },
+        "key": {
+            "type": "string",
+            "index": "not_analyzed",
+            "store": true
+        },
+        "actors": {
+            "type": "string",
+            "display": "array",
+            "index": "not_analyzed",
+            "store": true
+        },
+        "tags": {
+            "type": "string",
+            "display": "array",
+            "index": "not_analyzed",
+            "store": true
+        },
+        "year": {
+            "type": "integer",
+            "store": true
+        },
+        "rating": {
+            "type": "string",
+            "store": true
+        },
+        "image": {
+            "type": "string",
+            "display": "image"
+        }
+    },
+    "aggregations": {
+        "tags": {
+            "type": "terms",
+            "field": "tags",
+            "size": 10,
+            "title": "Tags"
+        },
+        "actors_terms": {
+            "type": "terms",
+            "field": "actors",
+            "size": 10,
+            "title": "Actors"
+        },
+        "director_terms": {
+            "type": "terms",
+            "field": "director",
+            "size": 5,
+            "title": "Directors"
+        }
+    },
+    "sortings": {
+        "favorites": {
+            "title": "Favorites count",
+            "type": "normal",
+            "order": "desc",
+            "field": "favorites"
+        },
+        "played": {
+            "title": "Played count",
+            "type": "normal",
+            "order": "desc",
+            "field": "played"
+        },
+        "rating": {
+            "title": "Rating",
+            "type": "normal",
+            "order": "desc",
+            "field": "rating"
+        },
+        "mix": {
+            "title": "Rating",
+            "type": "normal",
+            "sort": [
+                { "name" : {"order" : "asc"}},
+                { "rating" : {"order" : "desc"}}
+            ]
+        },
+        "alphabetically": {
+            "title": "AZ",
+            "type": "normal",
+            "order": "asc",
+            "field": "name"
+        }
+    },
+    "table": {
+        "fields": [
+            "image",
+            "name",
+            "director",
+            "rating",
+            "year",
+            "votes"
+        ]
+    },
+    "test": true,
+    "updated_at": "2016-10-01T09:52:20.547Z"
+}

--- a/tests/item/sortingsSpec.js
+++ b/tests/item/sortingsSpec.js
@@ -1,0 +1,75 @@
+var should = require('should');
+var sinon = require('sinon');
+var assert = require('assert');
+var setup = require('./../mocks/setup');
+var request = require('supertest');
+var _ = require('underscore');
+
+setup.makeSuite('it tests sortings', function() {
+  var data = [
+    {id: 1, rating: 1, name: 'b'},
+    {id: 2, rating: 2, name: 'b'},
+    {id: 3, rating: 3, name: 'b'},
+    {id: 4, rating: 5, name: 'e'},
+    {id: 5, rating: 4, name: 'b'},
+    {id: 6, rating: 6, name: 'a'}
+  ];
+
+  var projectService = require('./../../src/services/project');
+  var collectionService = require('./../../src/services/collection');
+  var documentElastic = require('./../../src/elastic/data');
+  var elasticTools = require('./../../src/elastic/tools');
+
+  before(function(done) {
+    projectService.ensureCollectionAsync({
+      projectName: 'test',
+      collectionName: 'movie'
+    }).then(function(res) {
+      request(setup.getServer())
+      .post('/api/v1/items/movie')
+      .send(data)
+      .end(function afterRequest(err, res) {
+        res.should.have.property('status', 200);
+        return elasticTools.refreshAsync({
+        }).then(function(res) {
+          done();
+        });
+      });
+    });
+  });
+
+  it('should make basic sort', function(done) {
+    request(setup.getServer())
+      .get('/api/v1/items/movie?sort=alphabetically')
+      .end(function afterRequest(err, res) {
+        console.log(res.body.data.items);
+        res.should.have.property('status', 200);
+        res.body.pagination.should.have.property('total', 6);
+
+        _.map(res.body.data.items, 'name').should.eql(
+            ['a', 'b', 'b', 'b', 'b', 'e']
+        )
+        done();
+      });
+  });
+
+  it('should make multi field sorting', function(done) {
+    request(setup.getServer())
+      .get('/api/v1/items/movie?sort=mix')
+      .end(function afterRequest(err, res) {
+        res.should.have.property('status', 200);
+        res.body.pagination.should.have.property('total', 6);
+
+        console.log(JSON.stringify(res.body));
+
+        _.map(res.body.data.items, 'name').should.eql(
+            ['a', 'b', 'b', 'b', 'b', 'e']
+        )
+
+        _.map(res.body.data.items, 'rating').should.eql(
+            [6, 4, 3, 2, 1, 5]
+        )
+        done();
+      });
+  });
+});


### PR DESCRIPTION
- supports multi field sorting like https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
- divides searchAsync as searchAsync and queryBuilder which makes code more maintenable and testable
- added more tests to search query
- hacked elastic.js many times to make it working 

The example configuration for multi field sorting looks like:

```js
"sortings": {
  "mix": {
    "title": "Rating",
    "sort": [
      {
        "name": {
          "order": "asc"
        }
      },
      {
        "rating": {
          "order": "desc"
        }
      }
    ]
  }
}
```