### PR TITLE
example: privileged flag not required

### DIFF
--- a/examples/movies.md
+++ b/examples/movies.md
@@ -4,7 +4,7 @@
 
 ```bash
 docker pull itemsapi/itemsapi:latest
-docker run --privileged -it -p 3000:3000 itemsapi/itemsapi
+docker run -it -p 3000:3000 itemsapi/itemsapi
 ```
 
 ### Create configuration


### PR DESCRIPTION
The `--privileged` is not required and can be omitted, the API & website still works perfectly without it.